### PR TITLE
Fix RYB to RGB conversion

### DIFF
--- a/shaders/picker.frag
+++ b/shaders/picker.frag
@@ -15,27 +15,45 @@ uniform vec2 u_alphaSliderDimensions;
 
 const float PI = 3.14159265;
 
-vec3 trilinearInterpolate(vec3 p, vec3 v000, vec3 v100, vec3 v010, vec3 v001, vec3 v101, vec3 v011, vec3 v110, vec3 v111) {
-    return v000 * (1.0 - p.x) * (1.0 - p.y) * (1.0 - p.z) +
-           v100 * p.x * (1.0 - p.y) * (1.0 - p.z) +
-           v010 * (1.0 - p.x) * p.y * (1.0 - p.z) +
-           v001 * (1.0 - p.x) * (1.0 - p.y) * p.z +
-           v101 * p.x * (1.0 - p.y) * p.z +
-           v011 * (1.0 - p.x) * p.y * p.z +
-           v110 * p.x * p.y * (1.0 - p.z) +
-           v111 * p.x * p.y * p.z;
-}
-
 vec3 rybToRgb(vec3 ryb) {
-    return trilinearInterpolate(ryb, 
-        vec3(1.0, 1.0, 1.0), 
-        vec3(1.0, 0.0, 0.0), 
-        vec3(0.163, 0.373, 0.6), 
-        vec3(1.0, 1.0, 0.0), 
-        vec3(1.0, 0.5, 0.0), 
-        vec3(0.0, 0.66, 0.2),
-        vec3(0.5, 0.0, 0.5),
-        vec3(0.2, 0.094, 0.0));
+    float r = ryb.x;
+    float y = ryb.y;
+    float b = ryb.z;
+
+    // remove brightness/whiteness
+    float w = min(min(r, y), b);
+    r -= w;
+    y -= w;
+    b -= w;
+
+    float my = max(max(r, y), b);
+
+    // get the green out of the yellow and blue
+    float g = min(y, b);
+    y -= g;
+    b -= g;
+
+    if (b != 0.0 && g != 0.0) {
+        b *= 2.0;
+        g *= 2.0;
+    }
+
+    // redistribute the remaining yellow
+    r += y;
+    g += y;
+
+    // Create the final vector
+    vec3 rgb = vec3(r, g, b);
+
+    // normalize to values
+    float mg = max(max(r, g), b);
+    if(mg != 0.0) {
+        float n = my / mg;
+        rgb *= n;
+    }
+    rgb += w;
+
+    return 1.0 - rgb;
 }
 
 vec3 hsv2ryb(vec3 c) {
@@ -58,7 +76,7 @@ vec4 hueCircle () {
 
     float angle = atan(coordinates.y, coordinates.x) + 2.0 * PI;
     float hue = angle / (2.0 * PI);
-    
+
     vec3 circleRGB = hsvToRgb(vec3(hue, 1.0, 1.0));
 
     float radius = length(coordinates);
@@ -172,7 +190,7 @@ void main () {
 
     vec4 sbSquareColor = sbSquare();
     color = alphaBlend(color, sbSquareColor);
-    
+
     vec4 sbIndicatorColor = sbIndicator();
     color = alphaBlend(color, sbIndicatorColor);
 


### PR DESCRIPTION
The previous technique resulted in the darkest colour possible being brown.

I tried fixing the RYB interpolation cube constants as there was a mistake (I found the paper in which they were presented), but the browinish color remained.

So I used a different techique for the conversion which works wonderfully.

If there's any objections on the code I'll handle them.

## Before:
![image](https://cloud.githubusercontent.com/assets/6632271/22844618/d5d8785a-efe7-11e6-87fa-9a33992921ef.png)

## After:
![image](https://cloud.githubusercontent.com/assets/6632271/22844653/01ee5c3e-efe8-11e6-97c2-af910c142f9c.png)

This fixes #5.