### PR TITLE
Fix save button

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <body>
         <script type="text/template" id="main">
             <div id="ui">
-                <div id="clear-button" class="button">Clear</div><div id="save-button" class="button">Save</div>
+                <div id="clear-button" class="button">Clear</div><a id="save-button" class="button">Save</a>
 
                 <div class="control-label">Quality</div>
                 <div class="buttons" id="qualities"></div>

--- a/paint.css
+++ b/paint.css
@@ -41,6 +41,7 @@ body {
     cursor: pointer;
 
     pointer-events: auto;
+    text-decoration: none;
 }
 
 #clear-button {

--- a/paint.js
+++ b/paint.js
@@ -913,6 +913,10 @@ var Paint = (function () {
     };
 
     Paint.prototype.save = function () {
+        //reset attributes so nothing gets saved if we hit an error somewhere
+        this.saveButton.removeAttribute('download');
+        this.saveButton.setAttribute('href', '#');
+
         //we first render the painting to a WebGL texture
 
         var wgl = this.wgl;
@@ -971,7 +975,8 @@ var Paint = (function () {
         imageData.data.set(savePixels);
         saveContext.putImageData(imageData, 0, 0);
 
-        window.open(saveCanvas.toDataURL());
+        this.saveButton.setAttribute('download', 'painting.png');
+        this.saveButton.setAttribute('href', saveCanvas.toDataURL());
     };
 
     Paint.prototype.onMouseMove = function (event) {


### PR DESCRIPTION
Patch for #14. Some browsers no longer allow top frame navigation to data URLs (https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/GbVcuwg_QjM%5B1-25%5D).

This patch makes the save button an `<a>` tag, sets the `href` to the data URL on click, and adds a `download` attribute so it gets saved instead of opened.

Works for me on Chromium 76.0.3809.100 and Firefox 69.0.

*Really* nice app btw!