### PR TITLE
fixed a bug in brush.js

### DIFF
--- a/brush.js
+++ b/brush.js
@@ -1,7 +1,8 @@
 var Brush = (function () {
     'use strict';
 
-    var N_PREVIOUS_SPEEDS = 15; //how many previous speeds we store
+    const N_PREVIOUS_SPEEDS = 15; //how many previous speeds we store
+ 
 
     var SPLATS_PER_SEGMENT = 8;
 


### PR DESCRIPTION
In the brush.js code:

I replaced the following line of code 
var N_PREVIOUS_SPEEDS = 15; //how many previous speeds we store

with:
const N_PREVIOUS_SPEEDS = 15; //how many previous speeds we store

Reason:
In this case, N_PREVIOUS_SPEEDS is intended to represent the number of previous speeds stored, and its value is not expected to change. By using const, you provide clarity to anyone reading the code that this variable is meant to be constant throughout the program.
